### PR TITLE
Bump to ejs to resolve https://security.snyk.io/vuln/SNYK-JS-ASYNC-2441827

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "license": "MIT",
   "dependencies": {
     "deep-extend": "^0.5.1",
-    "ejs": "^3.1.6",
+    "ejs": "^3.1.7",
     "loader-utils": "0.2.x",
     "minimatch": "^3.0.3",
     "slash": "^1.0.0"


### PR DESCRIPTION
This will update ejs to use 3.1.7, which updates jake, which updates async to 3.2.3 and resolves https://security.snyk.io/vuln/SNYK-JS-ASYNC-2441827

Feel free to see https://github.com/jakejs/jake/pull/411 for more information