### PR TITLE
Catch promise that might fail due to a cache bug in safari

### DIFF
--- a/lib/misc/sw-template.js
+++ b/lib/misc/sw-template.js
@@ -290,7 +290,9 @@ function WebpackServiceWorker(params, helpers) {
         // Preload is used only if navigationPreload is enabled and
         // navigationPreload mapping is not used.
         if (navigationPreload === true) {
-          event.respondWith(fetchWithPreload(event));
+          event.respondWith(fetchWithPreload(event)['catch'](function () {
+            return fetch(event.request);
+          }));
           return;
         }
       }
@@ -300,7 +302,9 @@ function WebpackServiceWorker(params, helpers) {
         var preloadedResponse = retrivePreloadedResponse(event);
 
         if (preloadedResponse) {
-          event.respondWith(preloadedResponse);
+          event.respondWith(Promise.resolve(preloadedResponse)['catch'](function () {
+            return fetch(event.request);
+          }));
           return;
         }
       }
@@ -321,7 +325,9 @@ function WebpackServiceWorker(params, helpers) {
         resource = cacheFirstResponse(event, urlString, cacheUrl);
       }
 
-    event.respondWith(resource);
+    event.respondWith(resource['catch'](function () {
+      return fetch(event.request);
+    }));
   });
 
   self.addEventListener('message', function (e) {
@@ -371,7 +377,7 @@ function WebpackServiceWorker(params, helpers) {
               console.log('[SW]:', 'Cache asset: ' + urlString);
             });
 
-            event.waitUntil(storing);
+            event.waitUntil(storing['catch'](function () {}));
           })();
         }
 
@@ -475,7 +481,7 @@ function WebpackServiceWorker(params, helpers) {
       });
     });
 
-    event.waitUntil(storing);
+    event.waitUntil(storing['catch'](function () {}));
   }
 
   function retriveInMemoryPreloadedResponse(url) {
@@ -512,7 +518,7 @@ function WebpackServiceWorker(params, helpers) {
     if (fromMemory) {
       event.waitUntil(caches.open(PRELOAD_CACHE_NAME).then(function (cache) {
         return cache['delete'](request);
-      }));
+      })['catch'](function () {}));
 
       return fromMemory;
     }
@@ -521,7 +527,7 @@ function WebpackServiceWorker(params, helpers) {
       if (response) {
         event.waitUntil(caches.open(PRELOAD_CACHE_NAME).then(function (cache) {
           return cache['delete'](request);
-        }));
+        })['catch'](function () {}));
       }
 
       return response || fetch(event.request);

--- a/src/misc/sw-template.js
+++ b/src/misc/sw-template.js
@@ -304,7 +304,7 @@ function WebpackServiceWorker(params, helpers) {
         // Preload is used only if navigationPreload is enabled and
         // navigationPreload mapping is not used.
         if (navigationPreload === true) {
-          event.respondWith(fetchWithPreload(event));
+          event.respondWith(fetchWithPreload(event).catch(() => fetch(event.request)));
           return;
         }
       }
@@ -314,7 +314,7 @@ function WebpackServiceWorker(params, helpers) {
         const preloadedResponse = retrivePreloadedResponse(event);
 
         if (preloadedResponse) {
-          event.respondWith(preloadedResponse);
+          event.respondWith(Promise.resolve(preloadedResponse).catch(() => fetch(event.request)));
           return;
         }
       }
@@ -335,7 +335,7 @@ function WebpackServiceWorker(params, helpers) {
       resource = cacheFirstResponse(event, urlString, cacheUrl);
     }
 
-    event.respondWith(resource);
+    event.respondWith(resource.catch(() => fetch(event.request)));
   });
 
   self.addEventListener('message', (e) => {
@@ -387,7 +387,7 @@ function WebpackServiceWorker(params, helpers) {
             console.log('[SW]:', 'Cache asset: ' + urlString);
           });
 
-          event.waitUntil(storing);
+          event.waitUntil(storing.catch(() => {}));
         }
 
         return response;
@@ -494,7 +494,7 @@ function WebpackServiceWorker(params, helpers) {
       });
     });
 
-    event.waitUntil(storing);
+    event.waitUntil(storing.catch(() => {}));
   }
 
   function retriveInMemoryPreloadedResponse(url) {
@@ -534,7 +534,7 @@ function WebpackServiceWorker(params, helpers) {
 
     if (fromMemory) {
       event.waitUntil(
-        caches.open(PRELOAD_CACHE_NAME).then(cache => cache.delete(request))
+        caches.open(PRELOAD_CACHE_NAME).then(cache => cache.delete(request)).catch(() => {})
       );
 
       return fromMemory;
@@ -543,7 +543,7 @@ function WebpackServiceWorker(params, helpers) {
     return cachesMatch(request, PRELOAD_CACHE_NAME).then(response => {
       if (response) {
         event.waitUntil(
-          caches.open(PRELOAD_CACHE_NAME).then(cache => cache.delete(request))
+          caches.open(PRELOAD_CACHE_NAME).then(cache => cache.delete(request)).catch(() => {})
         );
       }
 


### PR DESCRIPTION
Root causes identified in WebKit:

- Cache API timing bug — caches.match() throws because the cache "is not ready yet to communicate with"
- Null event.target — Safari nullifies event.target in SW under certain conditions
- Corrupted/cleared cache state — manual cache clearing while SW is registered causes internal errors