### PR TITLE
Make offline plugin rspack compatible

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -64,11 +64,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run fixture tests
-        run: pnpm run test:fixtures
-
       - name: Build lib/
         run: pnpm run build
+
+      - name: Run fixture tests
+        run: pnpm run test:fixtures
 
       - name: Resolve published version
         id: version
@@ -171,11 +171,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run fixture tests
-        run: pnpm run test:fixtures
-
       - name: Build lib/
         run: pnpm run build
+
+      - name: Run fixture tests
+        run: pnpm run test:fixtures
 
       - name: Configure git
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Unreleased
 
+* Add Rspack compatibility: replace `afterResolve` hook with a static module rule for runtime loader injection. Rspack ignores `createData.loaders` mutations in `afterResolve`, but static rules work in both webpack 5 and Rspack.
 * **BREAKING**: dropped `webpack@4` support. The plugin now requires `webpack@5` (or rspack). The legacy `compiler.plugin(...)` / `compiler.hooks.emit` / `compilation.cache` / direct `compilation.assets[x] =` code paths have been removed.
 * **BREAKING**: removed the `ServiceWorker.minify` option. Service-worker minification now follows the host bundler's `optimization.minimize` setting — whichever minifier the user configures (terser-webpack-plugin, swc-rspack, esbuild, …) naturally minifies the SW asset like any other JS asset. To skip SW minification while minifying the rest of the bundle, exclude it via the minimizer's `exclude` option. The `lib/misc/get-minification-plugin` module has been removed.
 * Fix [#5](https://github.com/LeComptoirDesPharmacies/offline-plugin/issues/5): removed the `Compilation.cache` deprecation warning and the "modifying assets after sealing" warning under webpack 5. The plugin now hooks into `compilation.hooks.processAssets` (`PROCESS_ASSETS_STAGE_SUMMARIZE`) and uses `emitAsset` / `deleteAsset` / `getAsset` with `compiler.webpack.sources.RawSource`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lcdp/offline-plugin",
-  "version": "5.1.7",
+  "version": "5.1.8-2",
   "description": "offline-plugin for webpack",
   "main": "lib/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -210,27 +210,24 @@ export default class OfflinePlugin {
       this.resolveToolPaths(tool, key, compiler);
     });
 
-    const afterResolveFn = (result, callback) => {
-      const createData = result.createData;
-      const resource = path.resolve(compiler.context, createData.resource);
-
-      if (resource === runtimePath) {
-        const data = {
-          autoUpdate: this.autoUpdate
-        };
-
-        this.useTools((tool, key) => {
-          data[key] = tool.getConfig(this);
-        });
-
-        createData.loaders.push({
-          loader: path.join(__dirname, 'misc/runtime-loader.js'),
-          options: JSON.stringify(data)
-        });
-      }
-
-      callback();
+    // Register runtime loader as a static module rule instead of injecting
+    // via afterResolve hook. Rspack ignores createData.loaders mutations
+    // in afterResolve, but static rules work in both webpack and Rspack.
+    const data = {
+      autoUpdate: this.autoUpdate
     };
+
+    this.useTools((tool, key) => {
+      data[key] = tool.getConfig(this);
+    });
+
+    compiler.options.module.rules.push({
+      test: runtimePath,
+      use: [{
+        loader: path.join(__dirname, 'misc/runtime-loader.js'),
+        options: JSON.stringify(data)
+      }]
+    });
 
     const makeFn = (compilation, callback) => {
       if (this.warnings.length) {
@@ -293,10 +290,6 @@ export default class OfflinePlugin {
     };
 
     const plugin = { name: 'OfflinePlugin' };
-
-    compiler.hooks.normalModuleFactory.tap(plugin, (nmf) => {
-      nmf.hooks.afterResolve.tapAsync(plugin, afterResolveFn);
-    });
 
     compiler.hooks.make.tapAsync(plugin, makeFn);
 


### PR DESCRIPTION
Replace `afterResolve` hook with a static module rule for runtime loader injection.
Rspack ignores `createData.loaders` mutations in `afterResolve`, but static rules work in both webpack 5 and Rspack.

